### PR TITLE
DEV: Rename plugin to discourse-post-voting

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,14 +1,14 @@
 [main]
 host = https://www.transifex.com
 
-[discourse-upvotes.client-en-yml]
+[discourse-post-voting.client-en-yml]
 file_filter = config/locales/client.<lang>.yml
 minimum_perc = 0
 source_file = config/locales/client.en.yml
 source_lang = en
 type = YML
 
-[discourse-upvotes.server-en-yml]
+[discourse-post-voting.server-en-yml]
 file_filter = config/locales/server.<lang>.yml
 source_file = config/locales/server.en.yml
 source_lang = en

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Discourse Upvotes
+# Discourse Post Voting
 
-![discourse upvotes](https://d11a6trkgmumsb.cloudfront.net/optimized/4X/f/e/5/fe50a4c07cc24ec0b10e64ec5d32154c7a140d9e_2_876x750.jpeg)
+![discourse post voting](https://d11a6trkgmumsb.cloudfront.net/optimized/4X/f/e/5/fe50a4c07cc24ec0b10e64ec5d32154c7a140d9e_2_876x750.jpeg)
 
 Please refer to https://meta.discourse.org/t/227808 for more info!
 

--- a/assets/javascripts/discourse/initializers/extend-composer-actions.js
+++ b/assets/javascripts/discourse/initializers/extend-composer-actions.js
@@ -38,7 +38,7 @@ export default {
       });
 
       api.modifyClass("component:composer-actions", {
-        pluginId: "discourse-upvotes",
+        pluginId: "discourse-post-voting",
 
         toggleQASelected(options, model) {
           model.toggleProperty("createAsQA");
@@ -78,7 +78,7 @@ export default {
       });
 
       api.modifyClass("model:composer", {
-        pluginId: "discourse-upvotes",
+        pluginId: "discourse-post-voting",
 
         @observes("categoryId")
         categoryCreateAsQADefault() {

--- a/assets/javascripts/discourse/initializers/qa-edits.js
+++ b/assets/javascripts/discourse/initializers/qa-edits.js
@@ -2,7 +2,7 @@ import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 export const ORDER_BY_ACTIVITY_FILTER = "activity";
-const pluginId = "discourse-upvotes";
+const pluginId = "discourse-post-voting";
 
 function initPlugin(api) {
   api.removePostMenuButton("reply", (attrs) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "discourse-upvotes",
+  "name": "discourse-post-voting",
   "version": "0.1",
-  "repository": "https://github.com/discourse/discourse-upvotes",
+  "repository": "https://github.com/discourse/discourse-post-voting",
   "author": "Alan Tan",
   "license": "MIT",
   "devDependencies": {

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# name: discourse-upvotes
-# about: Allows a topic to be created in the Q&A format
+# name: discourse-post-voting
+# about: Allows a topic's post to be voted on
 # version: 0.0.1
 # authors: Alan Tan
-# url: https://github.com/discourse/discourse-upvotes
+# url: https://github.com/discourse/discourse-post-voting
 # transpile_js: true
 
 %i[common mobile].each do |type|


### PR DESCRIPTION
Slicing https://github.com/discourse/discourse-post-voting/pull/110 since it's too big for reviewing -- renaming just the plugin.