### PR TITLE
FIX: Returns all post-voting fields for new posts

### DIFF
--- a/extensions/post_serializer_extension.rb
+++ b/extensions/post_serializer_extension.rb
@@ -21,6 +21,8 @@ module PostVoting
     end
 
     def comments
+      return [] if !@topic_view
+
       (@topic_view.comments[object.id] || []).map do |comment|
         serializer = QuestionAnswerCommentSerializer.new(comment, scope: scope, root: false)
         serializer.comments_user_voted = @topic_view.comments_user_voted
@@ -29,15 +31,15 @@ module PostVoting
     end
 
     def include_comments?
-      @topic_view && object.is_post_voting_topic?
+      object.is_post_voting_topic?
     end
 
     def comments_count
-      @topic_view.comments_counts&.dig(object.id) || 0
+      @topic_view&.comments_counts&.dig(object.id) || 0
     end
 
     def include_comments_count?
-      @topic_view && object.is_post_voting_topic?
+      object.is_post_voting_topic?
     end
 
     def post_voting_user_voted_direction
@@ -49,11 +51,11 @@ module PostVoting
     end
 
     def post_voting_has_votes
-      @topic_view.posts_voted_on.include?(object.id)
+      !!@topic_view&.posts_voted_on&.include?(object.id)
     end
 
     def include_post_voting_has_votes?
-      @topic_view && object.is_post_voting_topic?
+      object.is_post_voting_topic?
     end
 
     private

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -39,5 +39,19 @@ describe PostsController do
 
       expect(topic.is_post_voting?).to eq(false)
     end
+
+    it "returns all post-voting fields" do
+      topic = Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE)
+
+      post "/posts.json", params: {
+        raw: 'this is some raw',
+        topic_id: topic.id,
+      }
+
+      expect(response.parsed_body["post_voting_vote_count"]).to eq(0)
+      expect(response.parsed_body["post_voting_has_votes"]).to eq(false)
+      expect(response.parsed_body["comments"]).to eq([])
+      expect(response.parsed_body["comments_count"]).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
This was not always the case before because @topic_view was not set for
new posts. This had the unfortunate effect of not rendering the post as
a post-voting post, which meant there was no way to create a comment
without a page refresh after creating a post.