### PR TITLE
FIX: treat reply to first posts via email as answers.

### DIFF
--- a/extensions/post_extension.rb
+++ b/extensions/post_extension.rb
@@ -36,6 +36,7 @@ module PostVoting
     private
 
     def ensure_only_replies
+      return unless SiteSetting.qa_enabled
       if will_save_change_to_reply_to_post_number? &&
           reply_to_post_number &&
           reply_to_post_number != 1 &&

--- a/plugin.rb
+++ b/plugin.rb
@@ -200,4 +200,14 @@ after_initialize do
     ActiveModel::Type::Boolean.new.cast(self.custom_fields[PostVoting::CREATE_AS_POST_VOTING_DEFAULT])
   end
   add_to_serializer(:basic_category, :create_as_post_voting_default) { object.create_as_post_voting_default }
+
+  add_model_callback(:post, :before_create) do
+    if SiteSetting.qa_enabled &&
+       self.is_post_voting_topic? &&
+       self.via_email &&
+       self.reply_to_post_number == 1
+
+      self.reply_to_post_number = nil
+    end
+  end
 end

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -20,16 +20,12 @@ RSpec.describe Email::Receiver do
     fab!(:topic) { create_topic(category: category, user: user, subtype: Topic::POST_VOTING_SUBTYPE) }
     fab!(:post) { create_post(topic: topic) }
 
-    let!(:post_reply_key) do
+    before do
       Fabricate(:post_reply_key,
         reply_key: reply_key,
         user: user,
         post: post
       )
-    end
-
-    let :topic_user do
-      TopicUser.find_by(topic_id: topic.id, user_id: user.id)
     end
 
     it "creates a new reply post" do

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "email/receiver"
+
+RSpec.describe Email::Receiver do
+  before do
+    SiteSetting.email_in = true
+    SiteSetting.reply_by_email_address = "reply+%{reply_key}@bar.com"
+    SiteSetting.alternative_reply_by_email_addresses = "alt+%{reply_key}@bar.com"
+  end
+
+  def process(email_name, opts = {})
+    Email::Receiver.new(email(email_name), opts).process!
+  end
+
+  describe "reply" do
+    let(:reply_key) { "4f97315cc828096c9cb34c6f1a0d6fe8" }
+    fab!(:category) { Fabricate(:category) }
+    fab!(:user) { Fabricate(:user, email: "discourse@bar.com") }
+    fab!(:topic) { create_topic(category: category, user: user, subtype: Topic::POST_VOTING_SUBTYPE) }
+    fab!(:post) { create_post(topic: topic) }
+
+    let!(:post_reply_key) do
+      Fabricate(:post_reply_key,
+        reply_key: reply_key,
+        user: user,
+        post: post
+      )
+    end
+
+    let :topic_user do
+      TopicUser.find_by(topic_id: topic.id, user_id: user.id)
+    end
+
+    it "creates a new reply post" do
+      handler_calls = 0
+      handler = proc { |_| handler_calls += 1 }
+
+      DiscourseEvent.on(:topic_created, &handler)
+
+      expect { process(:html_reply) }.to change { topic.posts.count }
+      last_post = topic.posts.last
+      expect(last_post.raw).to eq("This is a **HTML** reply ;)")
+      expect(last_post.reply_to_post_number).to be_nil
+
+      DiscourseEvent.off(:topic_created, &handler)
+      expect(handler_calls).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Previosuly, it was added as embedded replies (post comments) instead of answers.