### PR TITLE
FIX: Remove style that is hiding reactions

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: ${{ matrix.build_type }}
     runs-on: ubuntu-latest
-    container: discourse/discourse_test:slim${{ startsWith(matrix.build_type, 'frontend') && '-browsers' || '' }}
+    container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}
     timeout-minutes: 30
 
     env:
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build_type: ["backend", "frontend"]
+        build_type: ['backend', 'frontend', 'system']
 
     steps:
       - uses: actions/checkout@v3
@@ -149,3 +149,18 @@ jobs:
         if: matrix.build_type == 'frontend' && steps.check_qunit.outputs.files_exist == 'true'
         run: QUNIT_EMBER_CLI=1 bundle exec rake plugin:qunit['${{ github.event.repository.name }}','1200000']
         timeout-minutes: 10
+
+      - name: Ember Build for System Tests
+        if: matrix.build_type == 'system'
+        run: bin/ember-cli --build
+
+      - name: Plugin System Tests
+        if: matrix.build_type == 'system'
+        run: LOAD_PLUGINS=1 bin/system_rspec plugins/*/spec/system
+
+      - name: Upload failed system test screenshots
+        uses: actions/upload-artifact@v3
+        if: matrix.build_type == 'system' && failure()
+        with:
+          name: failed-system-test-screenshots
+          path: tmp/screenshots/*.png

--- a/assets/stylesheets/common/post-voting.scss
+++ b/assets/stylesheets/common/post-voting.scss
@@ -15,11 +15,6 @@
       border-top: 1px solid var(--primary-low);
     }
   }
-
-  // disable reactions by default
-  .discourse-reactions-actions {
-    display: none;
-  }
 }
 
 .post-voting-answers-header {

--- a/spec/system/post_voting_spec.rb
+++ b/spec/system/post_voting_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Post Voting', type: :system, js: true do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:category1) { Fabricate(:category) }
+  fab!(:category2) { Fabricate(:category) }
+  fab!(:topic1) { Fabricate(:topic, category: category1) }
+  fab!(:topic2) { Fabricate(:topic, category: category1) }
+  fab!(:topic3) { Fabricate(:topic, category: category2) }
+  fab!(:post1) { Fabricate(:post, topic: topic1) }
+  fab!(:post2) { Fabricate(:post, topic: topic2) }
+  fab!(:category_page) { PageObjects::Pages::Category.new }
+  fab!(:topic_page) { PageObjects::Pages::Topic.new }
+  fab!(:user_page) { PageObjects::Pages::User.new }
+  fab!(:admin_page) { PageObjects::Pages::AdminSettings.new }
+
+  fab!(:composer) { PageObjects::Components::Composer.new }
+  fab!(:topic_list) { PageObjects::Components::TopicList.new }
+
+  before do
+    SiteSetting.qa_enabled = false
+
+    admin.activate
+    user.activate
+
+    sign_in(admin)
+  end
+
+  it 'enables post voting and creates a post-voting topic' do
+    # cannot create post voting topic
+    composer
+      .open_new_topic
+      .open_composer_actions
+    expect(composer).to have_no_css(composer.action("Toggle Post Voting"))
+
+    # enable post voting
+    admin_page
+      .visit_filtered_plugin_setting('plugin%3Adiscourse-post-voting')
+      .toggle_setting('qa_enabled', 'Enable Post Voting Plugin')
+
+    # create post voting topic
+    composer
+      .open_new_topic
+      .open_composer_actions
+      .select_action("Toggle Post Voting")
+    expect(composer.button_label).to have_text("Create post voting topic")
+    composer
+      .fill_title("The best cat in the world")
+      .fill_content("Who's the best cat in the world?")
+      .create
+
+    sign_out
+
+    sign_in(user)
+
+    topic_list.visit_topic_with_title("The best cat in the world")
+
+    # formatted as post voting topic
+    expect(topic_page).to have_css(".post-voting-topic")
+    expect(topic_page).to have_css(".post-menu-area .post-controls button[title='like this post']")
+  end
+end


### PR DESCRIPTION
We don't have to hide the reactions plugin using css. "Likes" and reactions should work nicely together with this change https://github.com/discourse/discourse/pull/18788

Requires https://github.com/discourse/discourse/pull/19421 to be merged.