### PR TITLE
FIX: category setting `create_as_post_voting_default` is not working as expected.

### DIFF
--- a/assets/javascripts/discourse/connectors/category-custom-settings/post-voting-category-settings.hbs
+++ b/assets/javascripts/discourse/connectors/category-custom-settings/post-voting-category-settings.hbs
@@ -1,7 +1,7 @@
 <h3>{{i18n "category.post_voting_settings_heading"}}</h3>
 <section class="field">
   <label>
-    <Input @type="checkbox" @checked={{this.category.custom_fields.create_as_post_voting_default}} />
+    <Input id="create-as-post-voting-default" @type="checkbox" @checked={{this.category.custom_fields.create_as_qa_default}} />
     {{i18n "category.create_as_post_voting_default"}}
   </label>
 </section>

--- a/test/javascripts/acceptance/category-edit-test.js
+++ b/test/javascripts/acceptance/category-edit-test.js
@@ -1,0 +1,24 @@
+import {
+  acceptance,
+} from "discourse/tests/helpers/qunit-helpers";
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import pretender from "discourse/tests/helpers/create-pretender";
+
+acceptance("Category Edit", function (needs) {
+  needs.user();
+  needs.settings({ qa_enabled: true });
+
+  test("Editing the category", async function (assert) {
+    await visit("/c/bug/edit/settings");
+    await click("#create-as-post-voting-default");
+
+    await click("#save-category");
+
+    const payload = JSON.parse(
+      pretender.handledRequests[pretender.handledRequests.length - 1]
+        .requestBody
+    );
+    assert.ok(payload.custom_fields.create_as_qa_default);
+  });
+});

--- a/test/javascripts/acceptance/category-edit-test.js
+++ b/test/javascripts/acceptance/category-edit-test.js
@@ -1,6 +1,4 @@
-import {
-  acceptance,
-} from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import pretender from "discourse/tests/helpers/create-pretender";


### PR DESCRIPTION
The setting `create_as_post_voting_default` should change the topic type to "post voting" when the category is selected in the composer while creating a new topic.