### PR TITLE
DEV: Replace #pluck_first monkey patch with native #pick

### DIFF
--- a/extensions/post_extension.rb
+++ b/extensions/post_extension.rb
@@ -18,7 +18,7 @@ module PostVoting
       QuestionAnswerVote
         .where(votable: self, user_id: user_id)
         .order(created_at: :desc)
-        .pluck_first(:created_at)
+        .pick(:created_at)
     end
 
     def post_voting_can_vote(user_id, direction = nil)

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -196,7 +196,7 @@ describe TopicView do
         TopicView.new(
           topic.id,
           user,
-          post_number: topic.posts.where("deleted_at IS NOT NULL").pluck_first(:post_number),
+          post_number: topic.posts.where("deleted_at IS NOT NULL").pick(:post_number),
         )
 
       expect(near_view.desired_post.id).to eq(post.id)


### PR DESCRIPTION
### What is this change?

We have replaced the `#pluck_first` freedom patch with the native `#pick` in core [here](https://github.com/discourse/discourse/pull/19893).

This change is updates this plugin in the same fashion.