### PR TITLE
FIX: adjust comments in RTL mode

### DIFF
--- a/assets/javascripts/discourse/widgets/post-voting-comment.js
+++ b/assets/javascripts/discourse/widgets/post-voting-comment.js
@@ -41,7 +41,9 @@ export default createWidget("post-voting-comment", {
     if (state.isEditing) {
       return [this.attach("post-voting-comment-editor", attrs)];
     } else {
-      const isRTLMode = document.querySelector("html").classList.contains("rtl");
+      const isRTLMode = document
+        .querySelector("html")
+        .classList.contains("rtl");
       const textDirection = isRTLMode ? "rtl" : "ltr";
       const result = [
         h(

--- a/assets/javascripts/discourse/widgets/post-voting-comment.js
+++ b/assets/javascripts/discourse/widgets/post-voting-comment.js
@@ -41,6 +41,8 @@ export default createWidget("post-voting-comment", {
     if (state.isEditing) {
       return [this.attach("post-voting-comment-editor", attrs)];
     } else {
+      const isRTLMode = document.querySelector("html").classList.contains("rtl");
+      const textDirection = isRTLMode ? "rtl" : "ltr";
       const result = [
         h(
           "span.post-voting-comment-cooked",
@@ -60,6 +62,11 @@ export default createWidget("post-voting-comment", {
         ),
         h(
           "span.post-voting-comment-info-created",
+          {
+            attributes: {
+              dir: textDirection,
+            },
+          },
           dateNode(new Date(attrs.created_at))
         ),
       ];

--- a/assets/stylesheets/common/post-voting.scss
+++ b/assets/stylesheets/common/post-voting.scss
@@ -137,7 +137,7 @@
     }
 
     .post-voting-comment-info-username {
-      display: inline;
+      display: inline-flex;
       margin-right: 0.3em;
     }
 
@@ -181,6 +181,20 @@
   &:hover {
     .post-voting-comment-actions {
       display: inline-block;
+    }
+  }
+}
+
+.rtl .post-voting-comment {
+  .post-voting-comment-post {
+    .post-voting-comment-info-username {
+      margin-right: 0;
+      margin-left: 0.3em;
+    }
+
+    .post-voting-comment-actions {
+      margin-left: 0;
+      margin-right: 0.3em;
     }
   }
 }


### PR DESCRIPTION
**PR Summary**:
The PR includes updates to the comments section to enable RTL mode. The images below illustrates the changes made, showcasing both LTR and RTL modes. As you might see, in RTL mode the text of the date and the username are intertwined, creating a mixed display. 

I drew inspiration from forums like Exchange and Stack Overflow. For instance, you can refer to this [link](https://stackoverflow.com/questions/15715825/how-do-you-get-the-git-repositorys-name-in-some-git-repository) where you'll find a SO post with `span.comment-date` element that contains `dir="ltr"` and `d-inline-flex` class, which uses `display: inline-flex` styling for the separator.

RTL mode:

![image](https://github.com/discourse/discourse-post-voting/assets/35470921/346a6628-dee4-484c-a3f5-4a0f9880adb8)


LTR mode:

![image](https://github.com/discourse/discourse-post-voting/assets/35470921/c3b756c9-a589-44c1-9b99-0b88c1497434)
