### PR TITLE
FIX: Handle empty topic views

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -104,9 +104,9 @@ after_initialize do
   TopicView.on_preload do |topic_view|
     next if !topic_view.topic.is_post_voting?
 
-    topic_view.comments = {}
-
     post_ids = topic_view.posts.pluck(:id)
+    next if post_ids.blank?
+
     post_ids_sql = post_ids.join(",")
 
     comment_ids_sql = <<~SQL
@@ -130,6 +130,7 @@ after_initialize do
     AND question_answer_comments.deleted_at IS NULL
     SQL
 
+    topic_view.comments = {}
     QuestionAnswerComment
       .includes(:user)
       .where("id IN (#{comment_ids_sql})")

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -33,6 +33,12 @@ describe TopicsController do
       )
     end
 
+    it "does not error for topic views without any posts" do
+      get "/t/#{topic.id}.json?page=2"
+
+      expect(response.status).to eq(404)
+    end
+
     it "orders posts by date of creation when 'activity' filter is provided" do
       get "/t/#{topic.id}.json?filter=#{TopicView::ACTIVITY_FILTER}"
 


### PR DESCRIPTION
Viewing an non-existing page generated an invalid topic view, with no posts, which lead to an invalid query.

Example of the error in logs:

```
ActiveRecord::StatementInvalid (PG::SyntaxError: ERROR:  syntax error at or near ")"
LINE 17: WHERE question_answer_comments.post_id IN ()
                                                    ^
)
```