### PR TITLE
FIX: Disallow voting on posts and comments for archived or closed topics

### DIFF
--- a/app/controllers/post_voting/votes_controller.rb
+++ b/app/controllers/post_voting/votes_controller.rb
@@ -133,37 +133,45 @@ module PostVoting
     end
 
     def ensure_can_vote(votable)
-      error_message = nil
-      error_message_params = {}
+      raiseError("post.post_voting.errors.vote_archived_topic") if votable.topic.archived?
+
+      raiseError("post.post_voting.errors.vote_closed_topic") if votable.topic.closed?
 
       if votable.user_id == current_user.id
-        error_message = "post.post_voting.errors.self_voting_not_permitted"
-      elsif votable.class.name == "Post"
+        raiseError("post.post_voting.errors.self_voting_not_permitted")
+      end
+
+      if votable.class.name == "Post"
         direction = vote_params[:direction] || QuestionAnswerVote.directions[:up]
         if QuestionAnswerVote.exists?(
              votable: votable,
              user_id: current_user.id,
              direction: direction,
            )
-          error_message = "vote.error.one_vote_per_post"
+          raiseError("vote.error.one_vote_per_post")
         elsif !PostVoting::VoteManager.can_undo(votable, current_user)
-          error_message = "vote.error.undo_vote_action_window"
-          error_message_params = { count: SiteSetting.post_voting_undo_vote_action_window.to_i }
+          raiseError(
+            "vote.error.undo_vote_action_window",
+            { count: SiteSetting.post_voting_undo_vote_action_window.to_i },
+          )
         end
-      elsif votable.class.name == "QuestionAnswerComment"
-        if QuestionAnswerVote.exists?(votable: votable, user: current_user)
-          error_message = "vote.error.one_vote_per_comment"
-        end
-      end
 
-      if error_message.present?
-        raise Discourse::InvalidAccess.new(
-                nil,
-                nil,
-                custom_message: error_message,
-                custom_message_params: error_message_params,
-              )
+        if votable.class.name == "QuestionAnswerComment" &&
+             QuestionAnswerVote.exists?(votable: votable, user: current_user)
+          raiseError("vote.error.one_vote_per_comment")
+        end
       end
+    end
+
+    private
+
+    def raiseError(error_message, error_message_params = nil)
+      raise Discourse::InvalidAccess.new(
+              nil,
+              nil,
+              custom_message: error_message,
+              custom_message_params: error_message_params,
+            )
     end
   end
 end

--- a/assets/javascripts/discourse/components/post-voting-button.hbs
+++ b/assets/javascripts/discourse/components/post-voting-button.hbs
@@ -1,6 +1,6 @@
 <DButton
   @class="btn-flat post-voting-button {{this.buttonClasses}}"
-  @disabled={{@loading}}
+  @disabled={{this.disabled}}
   @icon={{this.iconName}}
   {{on "click" this.onClick}}
 />

--- a/assets/javascripts/discourse/components/post-voting-button.js
+++ b/assets/javascripts/discourse/components/post-voting-button.js
@@ -12,11 +12,11 @@ export default class PostVotingButton extends Component {
       classes += " post-voting-button-voted";
     }
 
-    if (this.args.disabled) {
-      classes += " disabled";
-    }
-
     return classes;
+  }
+
+  get disabled() {
+    return this.args.disabled || this.args.loading;
   }
 
   get iconName() {

--- a/assets/javascripts/discourse/components/post-voting-button.js
+++ b/assets/javascripts/discourse/components/post-voting-button.js
@@ -12,6 +12,10 @@ export default class PostVotingButton extends Component {
       classes += " post-voting-button-voted";
     }
 
+    if (this.args.disabled) {
+      classes += " disabled";
+    }
+
     return classes;
   }
 

--- a/assets/javascripts/discourse/components/post-voting-comment.hbs
+++ b/assets/javascripts/discourse/components/post-voting-comment.hbs
@@ -24,6 +24,7 @@
         @voted={{@comment.user_voted}}
         @removeVote={{this.removeVote}}
         @vote={{if this.currentUser this.vote (route-action "showLogin")}}
+        @disabled={{@disabled}}
       />
     </div>
 

--- a/assets/javascripts/discourse/components/post-voting-comments.hbs
+++ b/assets/javascripts/discourse/components/post-voting-comments.hbs
@@ -6,6 +6,7 @@
       @updateComment={{this.updateComment}}
       @vote={{this.vote}}
       @removeVote={{this.removeVote}}
+      @disabled={{this.disabled}}
     />
   {{/each}}
 

--- a/assets/javascripts/discourse/components/post-voting-comments.js
+++ b/assets/javascripts/discourse/components/post-voting-comments.js
@@ -13,6 +13,10 @@ export default class PostVotingComments extends Component {
     return this.comments?.[this.comments.length - 1]?.id ?? 0;
   }
 
+  get disabled() {
+    return this.args.post.topic.closed || this.args.post.topic.archived;
+  }
+
   @action
   appendComments(comments) {
     this.comments.pushObjects(comments);

--- a/assets/javascripts/discourse/widgets/post-voting-button-shim.js
+++ b/assets/javascripts/discourse/widgets/post-voting-button-shim.js
@@ -10,5 +10,6 @@ registerWidgetShim(
     @voted={{@data.voted}}
     @removeVote={{@data.removeVote}}
     @vote={{@data.vote}}
+    @disabled={{@data.disabled}}
   />`
 );

--- a/assets/javascripts/discourse/widgets/post-voting-post.js
+++ b/assets/javascripts/discourse/widgets/post-voting-post.js
@@ -29,6 +29,7 @@ export default createWidget("post-voting-post", {
         voted: attrs.post.post_voting_user_voted_direction === "up",
         removeVote: this.removeVote.bind(this),
         vote: this.vote.bind(this),
+        disabled: attrs.post.topic.archived || attrs.post.topic.closed,
       }),
     ];
 
@@ -93,6 +94,7 @@ export default createWidget("post-voting-post", {
         voted: attrs.post.post_voting_user_voted_direction === "down",
         removeVote: this.removeVote.bind(this),
         vote: this.vote.bind(this),
+        disabled: attrs.post.topic.archived || attrs.post.topic.closed,
       })
     );
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,6 +7,8 @@ en:
         voting_not_permitted: "You are not allowed to vote on this post."
         comment_cannot_be_downvoted: "You can only upvote comments."
         self_voting_not_permitted: "You are not allowed to vote on your own post or comment."
+        vote_archived_topic: "You cannot vote on archived topics."
+        vote_closed_topic: "You cannot vote on closed topics."
   topic:
     post_voting:
       errors:

--- a/spec/requests/post_voting/votes_controller_spec.rb
+++ b/spec/requests/post_voting/votes_controller_spec.rb
@@ -49,6 +49,30 @@ RSpec.describe PostVoting::VotesController do
       expect(response.status).to eq(403)
     end
 
+    context "when topic archived or closed" do
+      it "returns an error when the topic is archived" do
+        topic.update(archived: true)
+
+        post "/post_voting/vote.json", params: { post_id: answer.id }
+
+        expect(response.status).to eq(403)
+        expect(JSON.parse(response.body)["errors"][0]).to eq(
+          I18n.t("post.post_voting.errors.vote_archived_topic", count: 1),
+        )
+      end
+
+      it "returns an error when the topic is closed" do
+        topic.update(closed: true)
+
+        post "/post_voting/vote.json", params: { post_id: answer.id }
+
+        expect(response.status).to eq(403)
+        expect(JSON.parse(response.body)["errors"][0]).to eq(
+          I18n.t("post.post_voting.errors.vote_closed_topic", count: 1),
+        )
+      end
+    end
+
     it "should return 403 if user votes on a post by self" do
       post "/post_voting/vote.json", params: { post_id: answer_3.id }
 

--- a/spec/system/page_objects/pages/post_voting_topic.rb
+++ b/spec/system/page_objects/pages/post_voting_topic.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class PostVotingTopic < PageObjects::Pages::Topic
+      COMMENT_VOTE_BUTTON = ".post-voting-comment-actions-vote button"
+      POST_VOTE_BUTTON = ".post-voting-post .post-voting-button-shim button"
+    end
+  end
+end

--- a/spec/system/post_voting_spec.rb
+++ b/spec/system/post_voting_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe "Post voting", type: :system do
 
     expect(page).to have_css(PageObjects::Pages::PostVotingTopic::POST_VOTE_BUTTON, count: 4)
     expect(page).to have_css(
-      "#{PageObjects::Pages::PostVotingTopic::POST_VOTE_BUTTON}.disabled",
+      "#{PageObjects::Pages::PostVotingTopic::POST_VOTE_BUTTON}:disabled",
       count: 4,
     )
-    expect(page).to have_css("#{PageObjects::Pages::PostVotingTopic::COMMENT_VOTE_BUTTON}.disabled")
+    expect(page).to have_css("#{PageObjects::Pages::PostVotingTopic::COMMENT_VOTE_BUTTON}:disabled")
   end
 end

--- a/spec/system/post_voting_spec.rb
+++ b/spec/system/post_voting_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe "Post voting", type: :system do
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+
+  let(:topic_page) { PageObjects::Pages::PostVotingTopic.new }
+
+  it "disallows voting on archived or closed topics" do
+    SiteSetting.post_voting_enabled = true
+    topic = Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE, user: user2, archived: true)
+    Fabricate(:post, topic: topic, post_number: 2)
+    post = Fabricate(:post, topic: topic, post_number: 3)
+    Fabricate(:post_voting_comment, post: post, user: user1)
+
+    sign_in(user1)
+
+    topic_page.visit_topic(topic)
+
+    expect(page).to have_css(PageObjects::Pages::PostVotingTopic::POST_VOTE_BUTTON, count: 4)
+    expect(page).to have_css(
+      "#{PageObjects::Pages::PostVotingTopic::POST_VOTE_BUTTON}.disabled",
+      count: 4,
+    )
+    expect(page).to have_css("#{PageObjects::Pages::PostVotingTopic::COMMENT_VOTE_BUTTON}.disabled")
+  end
+end


### PR DESCRIPTION
Disabled the voting buttons on posts and comments, and also returns an error properly if the frontend is bypassed.

https://meta.discourse.org/t/archiving-a-post-voting-topic-does-not-freeze-voting/253485/4

<img width="340" alt="Screenshot 2023-08-31 at 10 12 33 PM" src="https://github.com/discourse/discourse-post-voting/assets/1555215/c6d8bf7e-d5df-45ac-9309-b050faa5ef57">

