### PR TITLE
FIX: Show small action posts when sorted by activity

### DIFF
--- a/assets/stylesheets/common/post-voting.scss
+++ b/assets/stylesheets/common/post-voting.scss
@@ -15,6 +15,10 @@
       border-top: 1px solid var(--primary-low);
     }
   }
+
+  .posts-filtered-notice:empty {
+    display: none;
+  }
 }
 
 .post-voting-answers-header {

--- a/plugin.rb
+++ b/plugin.rb
@@ -86,13 +86,14 @@ after_initialize do
     if topic_view.topic.is_post_voting? &&
          !topic_view.instance_variable_get(:@replies_to_post_number) &&
          !topic_view.instance_variable_get(:@post_ids)
-      scope = scope.where(reply_to_post_number: nil, post_type: Post.types[:regular])
+      scope = scope.where(reply_to_post_number: nil)
 
       if topic_view.instance_variable_get(:@filter) != TopicView::ACTIVITY_FILTER
         scope =
-          scope.unscope(:order).order(
-            "CASE post_number WHEN 1 THEN 0 ELSE 1 END, qa_vote_count DESC, post_number ASC",
-          )
+          scope
+            .where(post_type: Post.types[:regular])
+            .unscope(:order)
+            .order("CASE post_number WHEN 1 THEN 0 ELSE 1 END, qa_vote_count DESC, post_number ASC")
       end
 
       scope

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -229,4 +229,26 @@ describe TopicView do
       )
     end
   end
+
+  describe "custom default scope filters" do
+    fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
+    fab!(:post_1) { create_post(topic: topic, raw: "kitties1", post_number: 1) }
+    fab!(:post_2) { create_post(topic: topic, raw: "kitties2", post_number: 2) }
+    fab!(:post_3) do
+      create_post(topic: topic, raw: "poopy", post_number: 3, post_type: Post.types[:small_action])
+    end
+    fab!(:post_4) { create_post(topic: topic, raw: "kitties4", post_number: 4) }
+
+    it "returns all posts in chronological order when filtered by ACTIVITY" do
+      topic_view = TopicView.new(topic.id, user, filter: TopicView::ACTIVITY_FILTER)
+
+      expect(topic_view.posts.map(&:raw)).to eq(%w[kitties1 kitties2 poopy kitties4])
+    end
+
+    it "returns only regular posts in chronological order when no filter" do
+      topic_view = TopicView.new(topic.id, user)
+
+      expect(topic_view.posts.map(&:raw)).to eq(%w[kitties1 kitties2 kitties4])
+    end
+  end
 end


### PR DESCRIPTION
Related meta topic: https://meta.discourse.org/t/whispers-and-small-action-posts-disappear-in-post-voting-topic/267567

The bug now is that in both Sort by "Votes" and Sort by "Activity", we are not showing small action posts when a topic is closed, archived, or an assignment.

This commit removes the filter when sorting by activity, since it is chronological and makes sense for small action posts to be in between votes.

<img width="378" alt="Screenshot 2023-09-04 at 7 48 47 PM" src="https://github.com/discourse/discourse-post-voting/assets/1555215/2d8caadf-9efb-4a9b-979b-0e93fe1bcee7">

Related:
There is still an outstanding bug where due to Sort by "Activity" being a `?filter=activity`, when a topic is closed, the returning post stream is empty and doesn't update the topic. That will be fixed in a separate PR.