### PR TITLE
DEV: Rename QuestionAnswerVote model to PostVotingVote

### DIFF
--- a/app/controllers/post_voting/votes_controller.rb
+++ b/app/controllers/post_voting/votes_controller.rb
@@ -86,10 +86,10 @@ module PostVoting
       # TODO: Probably a site setting to hide/show voters
       voters =
         User
-          .joins(:question_answer_votes)
-          .where(question_answer_votes: { votable_id: @post.id, votable_type: "Post" })
-          .order("question_answer_votes.created_at DESC")
-          .select("users.*", "question_answer_votes.direction")
+          .joins(:post_voting_votes)
+          .where(post_voting_votes: { votable_id: @post.id, votable_type: "Post" })
+          .order("post_voting_votes.created_at DESC")
+          .select("users.*", "post_voting_votes.direction")
           .limit(VOTERS_LIMIT)
 
       render_json_dump(voters: serialize_data(voters, BasicVoterSerializer))

--- a/app/controllers/post_voting/votes_controller.rb
+++ b/app/controllers/post_voting/votes_controller.rb
@@ -25,7 +25,7 @@ module PostVoting
       if PostVoting::VoteManager.vote(
            comment,
            current_user,
-           direction: QuestionAnswerVote.directions[:up],
+           direction: PostVotingVote.directions[:up],
          )
         render json: success_json
       else
@@ -65,7 +65,7 @@ module PostVoting
       comment = find_comment
       ensure_can_see_comment!(comment)
 
-      if !QuestionAnswerVote.exists?(votable: comment, user: current_user)
+      if !PostVotingVote.exists?(votable: comment, user: current_user)
         raise Discourse::InvalidAccess.new(
                 nil,
                 nil,
@@ -142,12 +142,8 @@ module PostVoting
 
         raise_error("post.post_voting.errors.vote_closed_topic") if votable.topic.closed?
 
-        direction = vote_params[:direction] || QuestionAnswerVote.directions[:up]
-        if QuestionAnswerVote.exists?(
-             votable: votable,
-             user_id: current_user.id,
-             direction: direction,
-           )
+        direction = vote_params[:direction] || PostVotingVote.directions[:up]
+        if PostVotingVote.exists?(votable: votable, user_id: current_user.id, direction: direction)
           raise_error("vote.error.one_vote_per_post")
         elsif !PostVoting::VoteManager.can_undo(votable, current_user)
           raise_error(
@@ -157,7 +153,7 @@ module PostVoting
         end
 
         if votable.class.name == "QuestionAnswerComment" &&
-             QuestionAnswerVote.exists?(votable: votable, user: current_user)
+             PostVotingVote.exists?(votable: votable, user: current_user)
           raise_error("vote.error.one_vote_per_comment")
         end
       end

--- a/app/models/post_voting_vote.rb
+++ b/app/models/post_voting_vote.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-class QuestionAnswerVote < ActiveRecord::Base
+class PostVotingVote < ActiveRecord::Base
+  self.table_name = "question_answer_votes"
   belongs_to :votable, polymorphic: true
   belongs_to :user
 
@@ -33,7 +34,7 @@ class QuestionAnswerVote < ActiveRecord::Base
   def ensure_valid_comment
     comment = votable
 
-    if direction != QuestionAnswerVote.directions[:up]
+    if direction != PostVotingVote.directions[:up]
       errors.add(:base, I18n.t("post.post_voting.errors.comment_cannot_be_downvoted"))
     end
 

--- a/app/models/question_answer_comment.rb
+++ b/app/models/question_answer_comment.rb
@@ -21,7 +21,7 @@ class QuestionAnswerComment < ActiveRecord::Base
 
   before_validation :cook_raw, if: :will_save_change_to_raw?
 
-  has_many :votes, class_name: "QuestionAnswerVote", as: :votable, dependent: :delete_all
+  has_many :votes, class_name: "PostVotingVote", as: :votable, dependent: :delete_all
 
   MARKDOWN_FEATURES = %w[censored emoji]
 

--- a/assets/javascripts/discourse/widgets/post-voting-user-commented-notification-item.js
+++ b/assets/javascripts/discourse/widgets/post-voting-user-commented-notification-item.js
@@ -6,7 +6,7 @@ import { buildAnchorId } from "../components/post-voting-comment";
 
 createWidgetFrom(
   DefaultNotificationItem,
-  "question-answer-user-commented-notification-item",
+  "post-voting-user-commented-notification-item",
   {
     url(data) {
       const attrs = this.attrs;

--- a/assets/javascripts/discourse/widgets/post-voting-user-commented-notification-item.js
+++ b/assets/javascripts/discourse/widgets/post-voting-user-commented-notification-item.js
@@ -6,7 +6,7 @@ import { buildAnchorId } from "../components/post-voting-comment";
 
 createWidgetFrom(
   DefaultNotificationItem,
-  "post-voting-user-commented-notification-item",
+  "question-answer-user-commented-notification-item",
   {
     url(data) {
       const attrs = this.attrs;

--- a/extensions/post_extension.rb
+++ b/extensions/post_extension.rb
@@ -15,15 +15,15 @@ module PostVoting
     end
 
     def post_voting_last_voted(user_id)
-      QuestionAnswerVote
+      PostVotingVote
         .where(votable: self, user_id: user_id)
         .order(created_at: :desc)
         .pick(:created_at)
     end
 
     def post_voting_can_vote(user_id, direction = nil)
-      direction ||= QuestionAnswerVote.directions[:up]
-      !QuestionAnswerVote.exists?(votable: self, user_id: user_id, direction: direction)
+      direction ||= PostVotingVote.directions[:up]
+      !PostVotingVote.exists?(votable: self, user_id: user_id, direction: direction)
     end
 
     def comments

--- a/extensions/post_extension.rb
+++ b/extensions/post_extension.rb
@@ -5,7 +5,7 @@ module PostVoting
     def self.included(base)
       base.ignored_columns = %w[vote_count]
 
-      base.has_many :question_answer_votes, as: :votable, dependent: :delete_all
+      base.has_many :post_voting_votes, as: :votable, dependent: :delete_all
       base.has_many :question_answer_comments, dependent: :destroy
       base.validate :ensure_only_replies
     end

--- a/extensions/topic_extension.rb
+++ b/extensions/topic_extension.rb
@@ -74,7 +74,7 @@ module PostVoting
 
         # This is a very inefficient way since the performance degrades as the
         # number of voted posts in the topic increases.
-        QuestionAnswerVote
+        PostVotingVote
           .joins("INNER JOIN posts ON posts.id = question_answer_votes.votable_id")
           .where(user: user, votable_type: "Post")
           .where("posts.topic_id = ?", topic.id)

--- a/extensions/user_extension.rb
+++ b/extensions/user_extension.rb
@@ -3,7 +3,7 @@
 module PostVoting
   module UserExtension
     def self.included(base)
-      base.has_many :question_answer_votes
+      base.has_many :post_voting_votes, class_name: "PostVotingVote"
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -67,7 +67,7 @@ after_initialize do
     @user_voted_posts ||= {}
 
     @user_voted_posts[user.id] ||= begin
-      QuestionAnswerVote.where(user: user, post: @posts).distinct.pluck(:post_id)
+      PostVotingVote.where(user: user, post: @posts).distinct.pluck(:post_id)
     end
   end
 
@@ -75,7 +75,7 @@ after_initialize do
     @user_voted_posts_last_timestamp ||= {}
 
     @user_voted_posts_last_timestamp[user.id] ||= begin
-      QuestionAnswerVote
+      PostVotingVote
         .where(user: user, post: @posts)
         .group(:votable_id, :created_at)
         .pluck(:votable_id, :created_at)
@@ -148,12 +148,12 @@ after_initialize do
     topic_view.comments_user_voted = {}
 
     if topic_view.guardian.user
-      QuestionAnswerVote
+      PostVotingVote
         .where(user: topic_view.guardian.user, votable_type: "Post", votable_id: post_ids)
         .pluck(:votable_id, :direction)
         .each { |post_id, direction| topic_view.posts_user_voted[post_id] = direction }
 
-      QuestionAnswerVote
+      PostVotingVote
         .joins(
           "INNER JOIN question_answer_comments comments ON comments.id = question_answer_votes.votable_id",
         )
@@ -164,10 +164,7 @@ after_initialize do
     end
 
     topic_view.posts_voted_on =
-      QuestionAnswerVote
-        .where(votable_type: "Post", votable_id: post_ids)
-        .distinct
-        .pluck(:votable_id)
+      PostVotingVote.where(votable_type: "Post", votable_id: post_ids).distinct.pluck(:votable_id)
   end
 
   add_permitted_post_create_param(:create_as_post_voting)

--- a/plugin.rb
+++ b/plugin.rb
@@ -29,7 +29,7 @@ after_initialize do
     ../app/validators/question_answer_comment_validator.rb
     ../app/controllers/post_voting/votes_controller.rb
     ../app/controllers/post_voting/comments_controller.rb
-    ../app/models/question_answer_vote.rb
+    ../app/models/post_voting_vote.rb
     ../app/models/question_answer_comment.rb
     ../app/serializers/basic_voter_serializer.rb
     ../app/serializers/question_answer_comment_serializer.rb

--- a/spec/components/post_voting/vote_manager_spec.rb
+++ b/spec/components/post_voting/vote_manager_spec.rb
@@ -130,7 +130,7 @@ describe PostVoting::VoteManager do
       vote_8 = PostVoting::VoteManager.vote(comment_3, other_user_2, direction: up)
 
       expect(PostVotingVote.exists?(id: [vote_1.id, vote_2.id, vote_3.id, vote_4.id])).to eq(true)
-      expect(user.question_answer_votes.count).to eq(4)
+      expect(user.post_voting_votes.count).to eq(4)
       expect(PostVotingVote.count).to eq(8)
 
       expect(post.qa_vote_count).to eq(-2)

--- a/spec/components/post_voting/vote_manager_spec.rb
+++ b/spec/components/post_voting/vote_manager_spec.rb
@@ -9,8 +9,8 @@ describe PostVoting::VoteManager do
   fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
   fab!(:topic_post) { Fabricate(:post, topic: topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }
-  fab!(:up) { QuestionAnswerVote.directions[:up] }
-  fab!(:down) { QuestionAnswerVote.directions[:down] }
+  fab!(:up) { PostVotingVote.directions[:up] }
+  fab!(:down) { PostVotingVote.directions[:down] }
 
   before { SiteSetting.post_voting_enabled = true }
 
@@ -23,7 +23,7 @@ describe PostVoting::VoteManager do
           end
           .first
 
-      expect(QuestionAnswerVote.exists?(votable: post, user: user, direction: up)).to eq(true)
+      expect(PostVotingVote.exists?(votable: post, user: user, direction: up)).to eq(true)
 
       expect(post.qa_vote_count).to eq(1)
 
@@ -42,7 +42,7 @@ describe PostVoting::VoteManager do
           end
           .first
 
-      expect(QuestionAnswerVote.exists?(votable: post, user: user, direction: down)).to eq(true)
+      expect(PostVotingVote.exists?(votable: post, user: user, direction: down)).to eq(true)
 
       expect(post.qa_vote_count).to eq(-1)
 
@@ -82,7 +82,7 @@ describe PostVoting::VoteManager do
           end
           .first
 
-      expect(QuestionAnswerVote.exists?(id: vote.id)).to eq(false)
+      expect(PostVotingVote.exists?(id: vote.id)).to eq(false)
       expect(vote.votable.qa_vote_count).to eq(0)
 
       expect(message.data[:id]).to eq(post.id)
@@ -106,7 +106,7 @@ describe PostVoting::VoteManager do
           end
           .first
 
-      expect(QuestionAnswerVote.exists?(id: vote_3.id)).to eq(false)
+      expect(PostVotingVote.exists?(id: vote_3.id)).to eq(false)
     end
   end
 
@@ -129,11 +129,9 @@ describe PostVoting::VoteManager do
       vote_7 = PostVoting::VoteManager.vote(comment_1, other_user_1, direction: up)
       vote_8 = PostVoting::VoteManager.vote(comment_3, other_user_2, direction: up)
 
-      expect(QuestionAnswerVote.exists?(id: [vote_1.id, vote_2.id, vote_3.id, vote_4.id])).to eq(
-        true,
-      )
+      expect(PostVotingVote.exists?(id: [vote_1.id, vote_2.id, vote_3.id, vote_4.id])).to eq(true)
       expect(user.question_answer_votes.count).to eq(4)
-      expect(QuestionAnswerVote.count).to eq(8)
+      expect(PostVotingVote.count).to eq(8)
 
       expect(post.qa_vote_count).to eq(-2)
       expect(topic_post.qa_vote_count).to eq(2)
@@ -143,13 +141,9 @@ describe PostVoting::VoteManager do
 
       PostVoting::VoteManager.bulk_remove_votes_by(user)
 
-      expect(QuestionAnswerVote.exists?(id: [vote_1.id, vote_2.id, vote_3.id, vote_4.id])).to eq(
-        false,
-      )
-      expect(QuestionAnswerVote.exists?(id: [vote_5.id, vote_6.id, vote_7.id, vote_8.id])).to eq(
-        true,
-      )
-      expect(QuestionAnswerVote.count).to eq(4)
+      expect(PostVotingVote.exists?(id: [vote_1.id, vote_2.id, vote_3.id, vote_4.id])).to eq(false)
+      expect(PostVotingVote.exists?(id: [vote_5.id, vote_6.id, vote_7.id, vote_8.id])).to eq(true)
+      expect(PostVotingVote.count).to eq(4)
 
       expect(post.reload.qa_vote_count).to eq(-1)
       expect(topic_post.reload.qa_vote_count).to eq(1)

--- a/spec/fabricators/post_voting_vote_fabricator.rb
+++ b/spec/fabricators/post_voting_vote_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Fabricator(:post_voting_vote, class_name: :question_answer_vote) do
+Fabricator(:post_voting_vote, class_name: :post_voting_vote) do
   user
   votable(fabricator: :post)
   direction "up"

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -19,7 +19,7 @@ describe TopicView do
       :post_voting_vote,
       votable: answer_2,
       user: user,
-      direction: QuestionAnswerVote.directions[:down],
+      direction: PostVotingVote.directions[:down],
     )
   end
 
@@ -58,8 +58,8 @@ describe TopicView do
 
     expect(topic_view.posts_user_voted).to eq(
       {
-        answer.id => QuestionAnswerVote.directions[:up],
-        answer_2.id => QuestionAnswerVote.directions[:down],
+        answer.id => PostVotingVote.directions[:up],
+        answer_2.id => PostVotingVote.directions[:down],
       },
     )
 
@@ -96,16 +96,8 @@ describe TopicView do
 
     fab!(:answer_plus_2_votes) do
       create_post(topic: topic).tap do |p|
-        PostVoting::VoteManager.vote(
-          p,
-          Fabricate(:user),
-          direction: QuestionAnswerVote.directions[:up],
-        )
-        PostVoting::VoteManager.vote(
-          p,
-          Fabricate(:user),
-          direction: QuestionAnswerVote.directions[:up],
-        )
+        PostVoting::VoteManager.vote(p, Fabricate(:user), direction: PostVotingVote.directions[:up])
+        PostVoting::VoteManager.vote(p, Fabricate(:user), direction: PostVotingVote.directions[:up])
       end
     end
 
@@ -114,12 +106,12 @@ describe TopicView do
         PostVoting::VoteManager.vote(
           p,
           Fabricate(:user),
-          direction: QuestionAnswerVote.directions[:down],
+          direction: PostVotingVote.directions[:down],
         )
         PostVoting::VoteManager.vote(
           p,
           Fabricate(:user),
-          direction: QuestionAnswerVote.directions[:down],
+          direction: PostVotingVote.directions[:down],
         )
       end
     end
@@ -129,7 +121,7 @@ describe TopicView do
         PostVoting::VoteManager.vote(
           p,
           Fabricate(:user),
-          direction: QuestionAnswerVote.directions[:down],
+          direction: PostVotingVote.directions[:down],
         )
       end
     end
@@ -138,22 +130,14 @@ describe TopicView do
 
     fab!(:answer_plus_1_vote_deleted) do
       create_post(topic: topic).tap do |p|
-        PostVoting::VoteManager.vote(
-          p,
-          Fabricate(:user),
-          direction: QuestionAnswerVote.directions[:up],
-        )
+        PostVoting::VoteManager.vote(p, Fabricate(:user), direction: PostVotingVote.directions[:up])
         p.trash!
       end
     end
 
     fab!(:answer_plus_1_vote) do
       create_post(topic: topic).tap do |p|
-        PostVoting::VoteManager.vote(
-          p,
-          Fabricate(:user),
-          direction: QuestionAnswerVote.directions[:up],
-        )
+        PostVoting::VoteManager.vote(p, Fabricate(:user), direction: PostVotingVote.directions[:up])
       end
     end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -9,7 +9,7 @@ describe Post do
   fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
   fab!(:topic_post) { Fabricate(:post, topic: topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }
-  let(:up) { QuestionAnswerVote.directions[:up] }
+  let(:up) { PostVotingVote.directions[:up] }
   let(:users) { [user1, user2, user3] }
 
   before { SiteSetting.post_voting_enabled = true }
@@ -39,10 +39,10 @@ describe Post do
   end
 
   it "should return post_voting_can_vote correctly" do
-    expect(post.post_voting_can_vote(user1.id, QuestionAnswerVote.directions[:up])).to eq(true)
+    expect(post.post_voting_can_vote(user1.id, PostVotingVote.directions[:up])).to eq(true)
 
     PostVoting::VoteManager.vote(post, user1)
 
-    expect(post.post_voting_can_vote(user1.id, QuestionAnswerVote.directions[:up])).to eq(false)
+    expect(post.post_voting_can_vote(user1.id, PostVotingVote.directions[:up])).to eq(false)
   end
 end

--- a/spec/models/post_voting_vote_spec.rb
+++ b/spec/models/post_voting_vote_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe QuestionAnswerVote do
+describe PostVotingVote do
   fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
   fab!(:topic_post) { Fabricate(:post, topic: topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }
@@ -18,11 +18,7 @@ describe QuestionAnswerVote do
         SiteSetting.post_voting_enabled = false
 
         vote =
-          QuestionAnswerVote.new(
-            votable: post,
-            user: user,
-            direction: QuestionAnswerVote.directions[:up],
-          )
+          PostVotingVote.new(votable: post, user: user, direction: PostVotingVote.directions[:up])
 
         expect(vote.valid?).to eq(false)
 
@@ -35,11 +31,7 @@ describe QuestionAnswerVote do
         post.update!(post_number: 2, reply_to_post_number: 1)
 
         vote =
-          QuestionAnswerVote.new(
-            votable: post,
-            user: user,
-            direction: QuestionAnswerVote.directions[:up],
-          )
+          PostVotingVote.new(votable: post, user: user, direction: PostVotingVote.directions[:up])
 
         expect(vote.valid?).to eq(false)
 
@@ -50,10 +42,10 @@ describe QuestionAnswerVote do
 
       it "ensures that votes can only be created for valid polymorphic types" do
         vote =
-          QuestionAnswerVote.new(
+          PostVotingVote.new(
             votable: post.topic,
             user: user,
-            direction: QuestionAnswerVote.directions[:up],
+            direction: PostVotingVote.directions[:up],
           )
 
         expect(vote.valid?).to eq(false)
@@ -62,11 +54,7 @@ describe QuestionAnswerVote do
 
       it "ensures that self voting is not allowed" do
         vote =
-          QuestionAnswerVote.new(
-            votable: post_1,
-            user: user,
-            direction: QuestionAnswerVote.directions[:up],
-          )
+          PostVotingVote.new(votable: post_1, user: user, direction: PostVotingVote.directions[:up])
 
         expect(vote.valid?).to eq(false)
         expect(vote.errors.full_messages).to contain_exactly(
@@ -83,10 +71,10 @@ describe QuestionAnswerVote do
         comment.reload
 
         vote =
-          QuestionAnswerVote.new(
+          PostVotingVote.new(
             votable: comment,
             user: user,
-            direction: QuestionAnswerVote.directions[:up],
+            direction: PostVotingVote.directions[:up],
           )
 
         expect(vote.valid?).to eq(false)
@@ -98,10 +86,10 @@ describe QuestionAnswerVote do
 
       it "ensures vote cannot be created on a comment when it is a downvote" do
         vote =
-          QuestionAnswerVote.new(
+          PostVotingVote.new(
             votable: comment,
             user: user,
-            direction: QuestionAnswerVote.directions[:down],
+            direction: PostVotingVote.directions[:down],
           )
 
         expect(vote.valid?).to eq(false)
@@ -115,7 +103,7 @@ describe QuestionAnswerVote do
 
   describe "#direction" do
     it "ensures inclusion of values" do
-      vote = QuestionAnswerVote.new(votable: post, user: user)
+      vote = PostVotingVote.new(votable: post, user: user)
 
       vote.direction = "up"
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -16,7 +16,7 @@ describe Topic do
     5.times.map { Fabricate(:post_voting_comment, post: answer) }.sort_by(&:created_at)
   end
 
-  let(:up) { QuestionAnswerVote.directions[:up] }
+  let(:up) { PostVotingVote.directions[:up] }
 
   describe "validations" do
     describe "#subtype" do

--- a/spec/requests/post_voting/votes_controller_spec.rb
+++ b/spec/requests/post_voting/votes_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe PostVoting::VotesController do
         post "/post_voting/vote.json",
              params: {
                post_id: answer.id,
-               direction: QuestionAnswerVote.directions[:down],
+               direction: PostVotingVote.directions[:down],
              }
 
         expect(response.status).to eq(403)
@@ -117,7 +117,7 @@ RSpec.describe PostVoting::VotesController do
       delete "/post_voting/vote.json", params: { post_id: answer.id }
 
       expect(response.status).to eq(200)
-      expect(QuestionAnswerVote.exists?(id: vote.id)).to eq(false)
+      expect(PostVotingVote.exists?(id: vote.id)).to eq(false)
     end
 
     it "should return the right response if user has never voted on post" do
@@ -169,7 +169,7 @@ RSpec.describe PostVoting::VotesController do
         :post_voting_vote,
         votable: answer,
         user: user_2,
-        direction: QuestionAnswerVote.directions[:down],
+        direction: PostVotingVote.directions[:down],
       )
       Fabricate(:post_voting_vote, votable: answer, user: user)
       Fabricate(:post_voting_vote, votable: answer_2, user: user)
@@ -189,10 +189,10 @@ RSpec.describe PostVoting::VotesController do
       expect(voters[0]["username"]).to eq(user.username)
       expect(voters[0]["name"]).to eq(user.name)
       expect(voters[0]["avatar_template"]).to eq(user.avatar_template)
-      expect(voters[0]["direction"]).to eq(QuestionAnswerVote.directions[:up])
+      expect(voters[0]["direction"]).to eq(PostVotingVote.directions[:up])
 
       expect(voters[1]["id"]).to eq(user_2.id)
-      expect(voters[1]["direction"]).to eq(QuestionAnswerVote.directions[:down])
+      expect(voters[1]["direction"]).to eq(PostVotingVote.directions[:down])
     end
   end
 
@@ -272,7 +272,7 @@ RSpec.describe PostVoting::VotesController do
     end
 
     it "should be able to remove a user's vote from a comment" do
-      PostVoting::VoteManager.vote(comment, user, direction: QuestionAnswerVote.directions[:up])
+      PostVoting::VoteManager.vote(comment, user, direction: PostVotingVote.directions[:up])
 
       sign_in(user)
 

--- a/spec/requests/post_voting/votes_controller_spec.rb
+++ b/spec/requests/post_voting/votes_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PostVoting::VotesController do
 
       expect(response.status).to eq(200)
 
-      vote = answer.question_answer_votes.first
+      vote = answer.post_voting_votes.first
 
       expect(vote.votable_type).to eq("Post")
       expect(vote.votable_id).to eq(answer.id)
@@ -109,7 +109,7 @@ RSpec.describe PostVoting::VotesController do
 
       expect(response.status).to eq(200)
 
-      vote = answer.question_answer_votes.first
+      vote = answer.post_voting_votes.first
 
       expect(vote.votable).to eq(answer)
       expect(vote.user_id).to eq(user.id)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -11,11 +11,11 @@ describe TopicsController do
   fab!(:answer_3) { create_post(topic: topic) }
 
   fab!(:vote) do
-    PostVoting::VoteManager.vote(answer_2, user, direction: QuestionAnswerVote.directions[:up])
+    PostVoting::VoteManager.vote(answer_2, user, direction: PostVotingVote.directions[:up])
   end
 
   fab!(:vote_2) do
-    PostVoting::VoteManager.vote(answer, user, direction: QuestionAnswerVote.directions[:down])
+    PostVoting::VoteManager.vote(answer, user, direction: PostVotingVote.directions[:down])
   end
 
   before { SiteSetting.post_voting_enabled = true }

--- a/spec/serializers/post_voting/topic_view_serializer_spec.rb
+++ b/spec/serializers/post_voting/topic_view_serializer_spec.rb
@@ -30,14 +30,14 @@ describe PostVoting::TopicViewSerializerExtension do
     posts = payload[:post_stream][:posts]
 
     expect(posts.first[:id]).to eq(topic_post.id)
-    expect(posts.first[:post_voting_user_voted_direction]).to eq(QuestionAnswerVote.directions[:up])
+    expect(posts.first[:post_voting_user_voted_direction]).to eq(PostVotingVote.directions[:up])
     expect(posts.first[:post_voting_has_votes]).to eq(true)
     expect(posts.first[:post_voting_vote_count]).to eq(1)
     expect(posts.first[:comments]).to eq([])
     expect(posts.first[:comments_count]).to eq(0)
 
     expect(posts.last[:id]).to eq(answer.id)
-    expect(posts.last[:post_voting_user_voted_direction]).to eq(QuestionAnswerVote.directions[:up])
+    expect(posts.last[:post_voting_user_voted_direction]).to eq(PostVotingVote.directions[:up])
     expect(posts.last[:post_voting_has_votes]).to eq(true)
     expect(posts.last[:post_voting_vote_count]).to eq(2)
     expect(posts.last[:comments].map { |c| c[:id] }).to contain_exactly(comment.id)

--- a/spec/serializers/question_answer/post_serializer_spec.rb
+++ b/spec/serializers/question_answer/post_serializer_spec.rb
@@ -9,7 +9,7 @@ describe PostVoting::PostSerializerExtension do
   fab!(:answer) { Fabricate(:post, topic: topic) }
   fab!(:comment) { Fabricate(:post_voting_comment, post: answer) }
   let(:topic_view) { TopicView.new(topic, user) }
-  let(:up) { QuestionAnswerVote.directions[:up] }
+  let(:up) { PostVotingVote.directions[:up] }
   let(:guardian) { Guardian.new(user) }
 
   let(:serialized) do


### PR DESCRIPTION
Only renaming the model name. This makes reviewing less complicated.

Migrations in a bit.