### PR TITLE
UX: Align the sort by buttons to the right of the post

### DIFF
--- a/assets/stylesheets/common/post-voting.scss
+++ b/assets/stylesheets/common/post-voting.scss
@@ -22,11 +22,13 @@
 }
 
 .post-voting-answers-header {
+  width: calc(
+    var(--topic-body-width) + var(--topic-body-width-padding) * 2 + 45px
+  );
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
   padding: 0.5em;
-  padding-right: 0;
 
   .post-voting-answers-headers-count {
     font-size: var(--font-up-1);


### PR DESCRIPTION
`var(--topic-body-width) + var(--topic-body-width-padding) * 2` comes from `.topic-body`, and `45px` comes from `.topic-avatar`.

Before:

![image](https://github.com/discourse/discourse-post-voting/assets/1555215/7d5c2174-276e-4133-a080-535695f0ef87)

After:

![Screenshot 2023-09-06 at 4 44 04 PM](https://github.com/discourse/discourse-post-voting/assets/1555215/74a71ddb-9730-445f-ae16-b95b0bb72a41)
