### PR TITLE
UX: Unset width for sorting methods on mobile

### DIFF
--- a/assets/stylesheets/common/post-voting.scss
+++ b/assets/stylesheets/common/post-voting.scss
@@ -22,9 +22,6 @@
 }
 
 .post-voting-answers-header {
-  width: calc(
-    var(--topic-body-width) + var(--topic-body-width-padding) * 2 + 45px
-  );
   box-sizing: border-box;
   display: flex;
   flex-direction: row;

--- a/assets/stylesheets/desktop/post-voting.scss
+++ b/assets/stylesheets/desktop/post-voting.scss
@@ -1,0 +1,5 @@
+.post-voting-answers-header {
+  width: calc(
+    var(--topic-body-width) + var(--topic-body-width-padding) * 2 + 45px
+  );
+}

--- a/assets/stylesheets/mobile/post-voting.scss
+++ b/assets/stylesheets/mobile/post-voting.scss
@@ -1,6 +1,7 @@
 .post-voting-topic,
 .post-voting-topic-sort-by-activity {
   .post-voting-answers-header {
+    width: unset;
     padding: 0;
     padding-bottom: 1em;
     border-top: none;

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,7 +7,9 @@
 # url: https://github.com/discourse/discourse-post-voting
 # transpile_js: true
 
-%i[common mobile].each { |type| register_asset "stylesheets/#{type}/post-voting.scss", type }
+%i[common mobile desktop].each do |type|
+  register_asset "stylesheets/#{type}/post-voting.scss", type
+end
 register_asset "stylesheets/common/post-voting-crawler.scss"
 
 enabled_site_setting :post_voting_enabled


### PR DESCRIPTION
As part of https://github.com/discourse/discourse-post-voting/pull/164 this bug was introduced where the two buttons would be far on the right in mobile.

<img width="649" alt="Screenshot 2023-09-07 at 10 50 44 AM" src="https://github.com/discourse/discourse-post-voting/assets/1555215/98867b64-a75b-42dd-b972-eb6924262b63">

This introduces a specific desktop stylesheet so the width set in the earlier PR can be applied to it.