### PR TITLE
DEV: Drop unused tables

### DIFF
--- a/db/post_migrate/20230908045625_drop_question_answer_tables.rb
+++ b/db/post_migrate/20230908045625_drop_question_answer_tables.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "migration/table_dropper"
+
+class DropQuestionAnswerTables < ActiveRecord::Migration[7.0]
+  def up
+    if table_exists?(:question_answer_votes)
+      Migration::TableDropper.execute_drop(:question_answer_votes)
+    end
+
+    if table_exists?(:question_answer_comments)
+      Migration::TableDropper.execute_drop(:question_answer_comments)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
They've been migrated to `post_voting_x`. So we can now safely drop them.

https://github.com/discourse/discourse-post-voting/pull/163