### PR TITLE
FIX: Post voting topic broken when OP is moderator action

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -93,7 +93,7 @@ after_initialize do
       if topic_view.instance_variable_get(:@filter) != TopicView::ACTIVITY_FILTER
         scope =
           scope
-            .where(post_type: Post.types[:regular])
+            .where.not(post_type: [Post.types[:whisper], Post.types[:small_action]])
             .unscope(:order)
             .order("CASE post_number WHEN 1 THEN 0 ELSE 1 END, qa_vote_count DESC, post_number ASC")
       end


### PR DESCRIPTION
Why this change?

A topic with post voting enabled will fail to render on the client side
when there is only the first post in the topic and the post is converted
to the `moderator_action` subtype.

This plugin adds a custom filter when fetching posts which is supposed to filter out
small actions and whispers. However, we were doing this in an incorrect
manner by filtering only for `regular` posts.

What does this change do?

This change updates our query filter to filter way whispers and small
actions instead of just filtering for regular topics.