### PR TITLE
FEATURE: default disable the plugin

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 plugins:
   post_voting_enabled:
     client: true
-    default: true
+    default: false
   post_voting_undo_vote_action_window:
     default: 10
   post_voting_comment_limit_per_post:

--- a/plugin.rb
+++ b/plugin.rb
@@ -15,6 +15,10 @@ register_asset "stylesheets/common/post-voting-crawler.scss"
 enabled_site_setting :post_voting_enabled
 
 after_initialize do
+  # a bit hacky, but we need this default enabled for tests so
+  # fab! calls work, without this we need to amend the boot process
+  SiteSetting.post_voting_enabled = true if Rails.env.test?
+
   %w[
     ../lib/post_voting/engine.rb
     ../lib/post_voting/vote_manager.rb


### PR DESCRIPTION
This follows the pattern of other plugins where post voting is only enabled
on demand, leading to less confusion

Contains a bit of hacky code cause we need to keep fabricators functional
in the test environment
