### PR TITLE
HOTFIX: Add category list preloading

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -188,7 +188,9 @@ after_initialize do
     Site.preloaded_category_custom_fields << PostVoting::CREATE_AS_POST_VOTING_DEFAULT
   end
   if self.respond_to?(:register_category_list_preloaded_category_custom_fields)
-    register_category_list_preloaded_category_custom_fields(PostVoting::CREATE_AS_POST_VOTING_DEFAULT)
+    register_category_list_preloaded_category_custom_fields(
+      PostVoting::CREATE_AS_POST_VOTING_DEFAULT,
+    )
   end
   add_to_class(:category, :create_as_post_voting_default) do
     ActiveModel::Type::Boolean.new.cast(

--- a/plugin.rb
+++ b/plugin.rb
@@ -187,6 +187,9 @@ after_initialize do
   if Site.respond_to? :preloaded_category_custom_fields
     Site.preloaded_category_custom_fields << PostVoting::CREATE_AS_POST_VOTING_DEFAULT
   end
+  if self.respond_to?(:register_category_list_preloaded_category_custom_fields)
+    register_category_list_preloaded_category_custom_fields(PostVoting::CREATE_AS_POST_VOTING_DEFAULT)
+  end
   add_to_class(:category, :create_as_post_voting_default) do
     ActiveModel::Type::Boolean.new.cast(
       self.custom_fields[PostVoting::CREATE_AS_POST_VOTING_DEFAULT],


### PR DESCRIPTION
This may be the cause of `/categories` returning a 500. (Hard to say for sure, I don't have a local repro.) 