### PR TITLE
DEV: Replace deprecated min_trust_to_create_post

### DIFF
--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Email::Receiver do
   describe "reply" do
     let(:reply_key) { "4f97315cc828096c9cb34c6f1a0d6fe8" }
     fab!(:category) { Fabricate(:category) }
-    fab!(:user) { Fabricate(:user, email: "discourse@bar.com") }
+    fab!(:user) { Fabricate(:user, email: "discourse@bar.com", refresh_auto_groups: true) }
     fab!(:topic) do
       create_topic(category: category, user: user, subtype: Topic::POST_VOTING_SUBTYPE)
     end

--- a/spec/system/post_voting_spec.rb
+++ b/spec/system/post_voting_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe "Post voting", type: :system do
-  fab!(:admin) { Fabricate(:admin) }
-  fab!(:user1) { Fabricate(:user) }
-  fab!(:user2) { Fabricate(:user) }
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
+  fab!(:user1) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:user2) { Fabricate(:user, refresh_auto_groups: true) }
 
   let(:topic_page) { PageObjects::Pages::PostVotingTopic.new }
 


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/24740, `min_trust_to_create_topic` site setting was replaced by `create_topic_allowed_groups`. This PR replaces the former, deprecated one, with the latter.