### PR TITLE
FIX: Customize New Button Compatibility with Post Voting Plugin

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-composer-actions.js
+++ b/assets/javascripts/discourse/initializers/extend-composer-actions.js
@@ -5,6 +5,7 @@ import I18n from "I18n";
 
 export default {
   name: "extend-composer-actions",
+  after: "chat-setup",
   initialize(container) {
     const siteSettings = container.lookup("site-settings:main");
 

--- a/assets/javascripts/discourse/initializers/extend-composer-actions.js
+++ b/assets/javascripts/discourse/initializers/extend-composer-actions.js
@@ -5,7 +5,7 @@ import I18n from "I18n";
 
 export default {
   name: "extend-composer-actions",
-  after: "chat-setup",
+  after: "inject-objects",
   initialize(container) {
     const siteSettings = container.lookup("site-settings:main");
 


### PR DESCRIPTION
**Context**
`discourse-customize-new-topic-button-text ` is a theme component that allows to customize the new topic button in different ways

**Problem**
For some reason, the post-voting plugin overrides the `discourse-customize-new-topic-button-text` behaviour and doesn't allow the user to customize the new topic button 

**Solution**
Add a hook so the initializer can be executed in an order where `discourse-customize-new-topic-button-text` theme component can customize the new topic button