### PR TITLE
DEV: Change min_trust_to_flag_posts_voting_comments to group setting

### DIFF
--- a/assets/javascripts/discourse/components/post-voting-comment-actions.js
+++ b/assets/javascripts/discourse/components/post-voting-comment-actions.js
@@ -31,9 +31,7 @@ export default class PostVotingCommentActions extends Component {
   get canFlag() {
     return (
       this.currentUser &&
-      (this.hasPermission ||
-        this.currentUser.trust_level >=
-          this.siteSettings.min_trust_to_flag_posts_voting_comments) &&
+      (this.hasPermission || this.currentUser.can_flag_post_voting_comments) &&
       !this.args.disabled
     );
   }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -26,6 +26,11 @@ en:
     post_voting_undo_vote_action_window: "Number of minutes users are allowed to undo votes in Post Voting topics (enter 0 for no limit)"
     post_voting_comment_limit_per_post: "Number of comments allowed on each post"
     min_trust_to_flag_posts_voting_comments: "Minimum trust level to flag a post voting comment"
+    flag_posts_voting_comments_allowed_groups: "Groups allowed to flag a post voting comment"
+
+    keywords:
+      flag_posts_voting_comments_allowed_groups: "min_trust_to_flag_posts_voting_comments"
+
 
   post_action_types:
     vote:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,10 +19,10 @@ plugins:
     default: 1
     enum: "TrustLevelSetting"
     client: true
+    hidden: true
   flag_posts_voting_comments_allowed_groups:
     default: "11" # auto group trust_level_1
     type: group_list
-    client: false
     allow_any: false
     refresh: true
     validator: "AtLeastOneGroupValidator"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,3 +19,10 @@ plugins:
     default: 1
     enum: "TrustLevelSetting"
     client: true
+  flag_posts_voting_comments_allowed_groups:
+    default: "11" # auto group trust_level_1
+    type: group_list
+    client: false
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"

--- a/db/post_migrate/20240122015930_fill_flag_post_voting_comments_allowed_groups_based_on_deprecated_setting.rb
+++ b/db/post_migrate/20240122015930_fill_flag_post_voting_comments_allowed_groups_based_on_deprecated_setting.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class FillFlagPostVotingCommentsAllowedGroupsBasedOnDeprecatedSetting < ActiveRecord::Migration[7.0]
+  def up
+    old_setting_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'min_trust_to_flag_posts_voting_comments' LIMIT 1",
+      ).first
+
+    if old_setting_trust_level.present?
+      allowed_groups = "1#{old_setting_trust_level}"
+
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('flag_posts_voting_comments_allowed_groups', :setting, '20', NOW(), NOW())",
+        setting: allowed_groups,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/post_voting/guardian_extension.rb
+++ b/lib/post_voting/guardian_extension.rb
@@ -18,7 +18,7 @@ module PostVoting
       return false if self.user.silenced?
       return true if self.user.staff?
 
-      self.user.trust_level >= SiteSetting.min_trust_to_flag_posts_voting_comments
+      self.user.in_any_groups?(SiteSetting.flag_posts_voting_comments_allowed_groups_map)
     end
 
     def can_flag_post_voting_comment?(comment)

--- a/plugin.rb
+++ b/plugin.rb
@@ -204,6 +204,10 @@ after_initialize do
     object.create_as_post_voting_default
   end
 
+  add_to_serializer(:current_user, :can_flag_post_voting_comments) do
+    scope.can_flag_post_voting_comments?
+  end
+
   register_category_custom_field_type(PostVoting::ONLY_POST_VOTING_IN_THIS_CATEGORY, :boolean)
   if Site.respond_to? :preloaded_category_custom_fields
     Site.preloaded_category_custom_fields << PostVoting::ONLY_POST_VOTING_IN_THIS_CATEGORY


### PR DESCRIPTION
New setting is flag_posts_voting_comments_allowed_groups

c.f. https://meta.discourse.org/t/changes-coming-to-settings-for-giving-access-to-features-from-trust-levels-to-groups/283408
