### PR TITLE
FIX: Next Page issues with crawlers

### DIFF
--- a/extensions/topic_view_extension.rb
+++ b/extensions/topic_view_extension.rb
@@ -94,8 +94,7 @@ module PostVoting
     end
 
     def post_voting_topic?
-      return false if !topic.is_post_voting? || @filter == TopicView::ACTIVITY_FILTER
-      true
+      topic.is_post_voting? && @filter != TopicView::ACTIVITY_FILTER
     end
   end
 end

--- a/extensions/topic_view_extension.rb
+++ b/extensions/topic_view_extension.rb
@@ -19,6 +19,26 @@ module PostVoting
       end
     end
 
+    def next_page
+      return super if !topic.is_post_voting?
+      return super if @filter == TopicView::ACTIVITY_FILTER
+
+      @highest_post_number = @filtered_posts.last.post_number
+
+      if @posts.blank?
+        @last_post = nil
+      else
+        @last_post ||= @posts.last
+      end
+
+      @next_page ||=
+        begin
+          if @last_post && @highest_post_number && (@highest_post_number != @last_post.post_number)
+            @page + 1
+          end
+        end
+    end
+
     # Monkey patch core's method. In an ideal world, we wouldn't have to do this here but `TopicView` in core does not
     # yet properly support ordering posts in any other order except by `Post#sort_order` and several methods in
     # core's `TopicView` is strongly tied to the assumption that posts are always ordered by `Post#sort_order`. Fixing
@@ -27,7 +47,7 @@ module PostVoting
     # to figure out what the "row_number" for each post. From there, we can then properly fetch the window of posts
     # near a given post number.
     def filter_posts_near(post_number)
-      return super unless topic.is_post_voting?
+      return super if !topic.is_post_voting?
       return super if @filter == TopicView::ACTIVITY_FILTER
 
       post_number = 1 if post_number == 0

--- a/extensions/topic_view_extension.rb
+++ b/extensions/topic_view_extension.rb
@@ -19,26 +19,6 @@ module PostVoting
       end
     end
 
-    def next_page
-      return super if !topic.is_post_voting?
-      return super if @filter == TopicView::ACTIVITY_FILTER
-
-      @highest_post_number = @filtered_posts.last.post_number
-
-      if @posts.blank?
-        @last_post = nil
-      else
-        @last_post ||= @posts.last
-      end
-
-      @next_page ||=
-        begin
-          if @last_post && @highest_post_number && (@highest_post_number != @last_post.post_number)
-            @page + 1
-          end
-        end
-    end
-
     # Monkey patch core's method. In an ideal world, we wouldn't have to do this here but `TopicView` in core does not
     # yet properly support ordering posts in any other order except by `Post#sort_order` and several methods in
     # core's `TopicView` is strongly tied to the assumption that posts are always ordered by `Post#sort_order`. Fixing
@@ -47,8 +27,7 @@ module PostVoting
     # to figure out what the "row_number" for each post. From there, we can then properly fetch the window of posts
     # near a given post number.
     def filter_posts_near(post_number)
-      return super if !topic.is_post_voting?
-      return super if @filter == TopicView::ACTIVITY_FILTER
+      return super if !post_voting_topic?
 
       post_number = 1 if post_number == 0
 
@@ -101,6 +80,22 @@ module PostVoting
       SQL
 
       filter_posts_by_ids(post_ids)
+    end
+
+    def next_page
+      return super if !post_voting_topic?
+
+      @highest_post_number = @filtered_posts.last.post_number
+
+      @next_page ||=
+        if last_post && @highest_post_number && (@highest_post_number != last_post.post_number)
+          @page + 1
+        end
+    end
+
+    def post_voting_topic?
+      return false if !topic.is_post_voting? || @filter == TopicView::ACTIVITY_FILTER
+      true
     end
   end
 end

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -213,6 +213,14 @@ describe TopicView do
         [answer_minus_2_votes.id, answer_minus_1_vote.id, answer_0_votes.id],
       )
     end
+    describe "#next_page" do
+      it "should return the next page properly when the highest id post is not the last" do
+        expect(
+          TopicView.new(topic.id, user, { post_number: post.post_number }).next_paspec / lib /
+            topic_view_spec.rbge,
+        ).to eql(2)
+      end
+    end
   end
 
   describe "custom default scope filters" do

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -215,10 +215,7 @@ describe TopicView do
     end
     describe "#next_page" do
       it "should return the next page properly when the highest id post is not the last" do
-        expect(
-          TopicView.new(topic.id, user, { post_number: post.post_number }).next_paspec / lib /
-            topic_view_spec.rbge,
-        ).to eql(2)
+        expect(TopicView.new(topic.id, user, { post_number: post.post_number }).next_page).to eql(2)
       end
     end
   end

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -214,7 +214,7 @@ describe TopicView do
       )
     end
     describe "#next_page" do
-      it "should return the next page properly when the highest id post is not the last" do
+      it "returns the next page properly when the highest id post is not the last" do
         expect(TopicView.new(topic.id, user, { post_number: post.post_number }).next_page).to eql(2)
       end
     end


### PR DESCRIPTION
**Context**
Currently, we have a monkey patch for Post voting plugin posts that allows us to load posts based a on different order than what `Post#sort_order` does. 

**Problem**
This is causing issues with crawlers (JS disabled) since we are displaying a `next_page` button that should not be there. This happens because the `next_page` logic is based on the supposition that the Post order is what `Post#sort_order` outputs. 

**Solution**
Make a `next_page` method that overrides core's implementation for Post voting Posts and works correctly with the custom order used in the plugin