### PR TITLE
FIX: Set topic subtype when embedding topics

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -192,8 +192,8 @@ after_initialize do
 
   register_modifier(:topic_embed_import_create_args) do |args|
     category_id = args[:category]
-    return args unless category_id
-    return args if args[:archetype] != Archetype.default && !args[:archetype].blank?
+    next args unless category_id
+    next args if args[:archetype] != Archetype.default && !args[:archetype].blank?
 
     category = Category.find_by(id: category_id)
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -190,6 +190,20 @@ after_initialize do
     false
   end
 
+  register_modifier(:topic_embed_import_create_args) do |args|
+    category_id = args[:category]
+    return args unless category_id
+    return args if args[:archetype] != Archetype.default && !args[:archetype].blank?
+
+    category = Category.find_by(id: category_id)
+
+    if category&.create_as_post_voting_default || category&.only_post_voting_in_this_category
+      args[:subtype] = Topic::POST_VOTING_SUBTYPE
+    end
+
+    args
+  end
+
   register_category_custom_field_type(PostVoting::CREATE_AS_POST_VOTING_DEFAULT, :boolean)
   if respond_to?(:register_preloaded_category_custom_fields)
     register_preloaded_category_custom_fields(PostVoting::CREATE_AS_POST_VOTING_DEFAULT)

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TopicEmbed do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  let(:title) { "How to turn a fish from good to evil in 30 seconds" }
+  let(:url) { "http://eviltrout.com/123" }
+  let(:contents) do
+    "<p>hello world new post <a href='/hello'>hello</a> <img src='images/wat.jpg'></p>"
+  end
+  fab!(:embeddable_host)
+  let(:category) { Fabricate(:category) }
+
+  it "creates the topic with the right subtype in a category with `create_as_post_voting_default == true`" do
+    category.custom_fields[PostVoting::CREATE_AS_POST_VOTING_DEFAULT] = true
+    category.save!
+
+    Jobs.run_immediately!
+    imported_post =
+      TopicEmbed.import(
+        user,
+        "http://eviltrout.com/abcd",
+        title,
+        "some random content",
+        category_id: category.id,
+      )
+
+    expect(imported_post.topic.category).to eq(category)
+    expect(imported_post.topic.subtype).to eq(Topic::POST_VOTING_SUBTYPE)
+  end
+
+  it "creates the topic with the right subtype in a category with `only_post_voting_in_this_category == true`" do
+    category.custom_fields[PostVoting::ONLY_POST_VOTING_IN_THIS_CATEGORY] = true
+    category.save!
+
+    Jobs.run_immediately!
+    imported_post =
+      TopicEmbed.import(
+        user,
+        "http://eviltrout.com/abcd",
+        title,
+        "some random content",
+        category_id: category.id,
+      )
+
+    expect(imported_post.topic.category).to eq(category)
+    expect(imported_post.topic.subtype).to eq(Topic::POST_VOTING_SUBTYPE)
+  end
+
+  it "doesn't change the subtype when the category is not set to use post voting by default" do
+    Jobs.run_immediately!
+    imported_post =
+      TopicEmbed.import(
+        user,
+        "http://eviltrout.com/abcd",
+        title,
+        "some random content",
+        category_id: category.id,
+      )
+
+    expect(imported_post.topic.category).to eq(category)
+    expect(imported_post.topic.subtype).not_to eq(Topic::POST_VOTING_SUBTYPE)
+  end
+end


### PR DESCRIPTION
This commit registers a modifier to set the subtype of a topic to `Topic::POST_VOTING_SUBTYPE` during the embedding process when certain conditions are met:

- a new topic is being created;
- the topic will be saved to a valid category;
- the category has either `create_as_post_voting_default` or `only_post_voting_in_this_category` set to `true`

This PR requires https://github.com/discourse/discourse/pull/26527 to be merged in core. DO NOT MERGE before that.