### PR TITLE
FIX: Add missing flag auto-silence reason translation

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -57,6 +57,7 @@ en:
         not_permitted: "Commenting on associated post is not permitted."
         limit_exceeded: "Limit of %{limit} comments per post has been reached."
         perform: "Post Voting Comment flagged with score high enough to silence user."
+        auto_silence_from_flags: "Automatically silenced due to flagging."
       reviewables:
         comment_already_handled: "Thanks, but we've already reviewed this comment and determined it does not need to be flagged again."
         actions:


### PR DESCRIPTION
### What is this change?

I am trying to enable `i18n.raise_on_missing_translations` in core. It caught a missing translation in this plugin. The translation is used as a reason for auto-silencing a user, so it has gone unnoticed until now.

**Before:**

```
Randomized with seed 58289
......FF

Failures:

  1) ReviewablePostVotingComment when the flagged comment author is silenced perform_disagree_and_restore unsilences the user
     Failure/Error: raise I18n::MissingTranslationData.new(locale, key)
     
     I18n::MissingTranslationData:
       Translation missing: en.post_voting.comment.errors.auto_silence_from_flags
     # ./lib/freedom_patches/translate_accelerator.rb:150:in `translate_no_override'
     # ./lib/freedom_patches/translate_accelerator.rb:227:in `translate'
     # ./plugins/discourse-post-voting/spec/models/reviewable_post_voting_comment_spec.rb:72:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:460:in `block (2 levels) in <top (required)>'

  2) ReviewablePostVotingComment when the flagged comment author is silenced perform_disagree unsilences the user
     Failure/Error: raise I18n::MissingTranslationData.new(locale, key)
     
     I18n::MissingTranslationData:
       Translation missing: en.post_voting.comment.errors.auto_silence_from_flags
     # ./lib/freedom_patches/translate_accelerator.rb:150:in `translate_no_override'
     # ./lib/freedom_patches/translate_accelerator.rb:227:in `translate'
     # ./plugins/discourse-post-voting/spec/models/reviewable_post_voting_comment_spec.rb:72:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:460:in `block (2 levels) in <top (required)>'

Finished in 1.8 seconds (files took 2.61 seconds to load)
8 examples, 2 failures

Failed examples:

rspec ./plugins/discourse-post-voting/spec/models/reviewable_post_voting_comment_spec.rb:82 # ReviewablePostVotingComment when the flagged comment author is silenced perform_disagree_and_restore unsilences the user
rspec ./plugins/discourse-post-voting/spec/models/reviewable_post_voting_comment_spec.rb:76 # ReviewablePostVotingComment when the flagged comment author is silenced perform_disagree unsilences the user

Randomized with seed 58289

```


**After:**

```
Randomized with seed 9957
........

Finished in 1.98 seconds (files took 2.37 seconds to load)
8 examples, 0 failures

Randomized with seed 9957
```