### PR TITLE
DEV: Fix mismatched column types in tests

### DIFF
--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
-RSpec.configure do |_|
+RSpec.configure do |config|
   # this is so that fabricators can fabricate
   # since the creation of some models require
   # the plugin to be turned on
   SiteSetting.post_voting_enabled = true
+
+  config.before(:suite) do
+    if defined?(migrate_column_to_bigint)
+      migrate_column_to_bigint(PostVotingCommentCustomField, :post_voting_comment_id)
+      migrate_column_to_bigint(PostVotingVote, :votable_id)
+    end
+  end
 end


### PR DESCRIPTION
The primary key is usually a bigint column, but the foreign key columns usually are of integer type. This can lead to issues when joining these columns due to mismatched types and different value ranges.

In a recent core change, all bigint sequences will start at a very high value in the test environment to surface this type of errors. The same change also added a temporary API that changes the column type to bigint in order to allow for the tests to run.

The plugin API is only temporary and it is important for these plugins to migrate their columns to bigint to avoid issues in the future.