### PR TITLE
DEV: Fix mismatched column types

### DIFF
--- a/db/migrate/20241025132600_alter_post_voting_ids_to_bigint.rb
+++ b/db/migrate/20241025132600_alter_post_voting_ids_to_bigint.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AlterPostVotingIdsToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :post_voting_comment_custom_fields, :post_voting_comment_id, :bigint
+    change_column :post_voting_votes, :votable_id, :bigint
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -5,11 +5,4 @@ RSpec.configure do |config|
   # since the creation of some models require
   # the plugin to be turned on
   SiteSetting.post_voting_enabled = true
-
-  config.before(:suite) do
-    if defined?(migrate_column_to_bigint)
-      migrate_column_to_bigint(PostVotingCommentCustomField, :post_voting_comment_id)
-      migrate_column_to_bigint(PostVotingVote, :votable_id)
-    end
-  end
 end


### PR DESCRIPTION
The primary key is usually a bigint column, but the foreign key columns are usually of integer type. This can lead to issues when joining these columns due to mismatched types and different value ranges.

This was using a temporary plugin / test API to make tests pass, but it is safe to alter these tables because they usually have less than 1M rows and migration is going to be fast.