### PR TITLE
FIX: delete reviewable when the user is deleted

### DIFF
--- a/spec/models/reviewable_post_voting_comment_spec.rb
+++ b/spec/models/reviewable_post_voting_comment_spec.rb
@@ -86,4 +86,13 @@ RSpec.describe ReviewablePostVotingComment, type: :model do
       expect(user.reload.silenced?).to eq(false)
     end
   end
+
+  context "when author of the flagged comment is deleted" do
+    it "deletes comment and review" do
+      UserDestroyer.new(Discourse.system_user).destroy(comment_poster, { delete_posts: true })
+      expect { comment_poster.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { comment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { reviewable.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
Currently, when the user is deleted we remove comments and votes.

However, if there is a linked reviewable to comment, it should be deleted as well because it cannot be actioned.

In addition, reviewable should be registered so it is available in admin filter.