### PR TITLE
DEV: Add plugin admin title

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8,6 +8,8 @@ en:
       comment_already_handled: "Thanks, but we've already reviewed this comment and determined it does not need to be flagged again."
 
   js:
+    discourse_post_voting:
+      title: "Post voting"
     notifications:
       question_answer_user_commented: "<span>%{username}</span> %{description}"
       titles:


### PR DESCRIPTION
### What is this change?

This adds a plugin title for the admin sidebar to use.

**Before:**

<img width="232" alt="Screenshot 2025-01-27 at 11 19 50 AM" src="https://github.com/user-attachments/assets/d55f99b5-c901-4897-8855-ae8d811b5b73" />

**After:**

<img width="241" alt="Screenshot 2025-01-27 at 11 19 27 AM" src="https://github.com/user-attachments/assets/3ba6c348-9f1f-4fd5-9ade-97f31c34c55a" />
