### PR TITLE
DEV: Update login screen checks in frontend tests

### DIFF
--- a/test/javascripts/acceptance/post-voting-test.js
+++ b/test/javascripts/acceptance/post-voting-test.js
@@ -248,14 +248,14 @@ acceptance("Discourse Post Voting - anon user", function (needs) {
     await visit("/t/280");
     await click(".post-voting-comment-add-link");
 
-    assert.dom(".login-modal").exists("displays the login modal");
+    assert.dom("#login-form").exists("displays the login screen");
   });
 
   test("voting a comment", async function (assert) {
     await visit("/t/280");
     await click("#post_2 #post-voting-comment-2 .post-voting-button-upvote");
 
-    assert.dom(".login-modal").exists("displays the login modal");
+    assert.dom("#login-form").exists("displays the login screen");
   });
 });
 

--- a/test/javascripts/acceptance/post-voting-widget-post-menu-test.js
+++ b/test/javascripts/acceptance/post-voting-widget-post-menu-test.js
@@ -252,14 +252,14 @@ acceptance(
       await visit("/t/280");
       await click(".post-voting-comment-add-link");
 
-      assert.dom(".login-modal").exists("displays the login modal");
+      assert.dom("#login-form").exists("displays the login form");
     });
 
     test("voting a comment", async function (assert) {
       await visit("/t/280");
       await click("#post_2 #post-voting-comment-2 .post-voting-button-upvote");
 
-      assert.dom(".login-modal").exists("displays the login modal");
+      assert.dom("#login-form").exists("displays the login form");
     });
   }
 );


### PR DESCRIPTION
Matching on `#login-form` means these pass for modal or full page login screens. (See failures in https://github.com/discourse/discourse/pull/31771)